### PR TITLE
[#9] 공통 버튼 컴포넌트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 function App() {
-  return <>hello</>;
+  <>
+  </>;
 }
 
 export default App;

--- a/src/components/common/Button.tsx
+++ b/src/components/common/Button.tsx
@@ -1,1 +1,51 @@
+import styled from "styled-components"
 
+interface DefaultButtonProps {
+    text: string;
+    width?: number;
+    disabled?: boolean;
+    onClick?:()=>void;
+    href?:string;
+}
+
+const DefaultBtn = styled.button<{ width?: number, disabled?: boolean }>`
+    background:unset;
+    border:unset;
+    cursor:${(props)=>props.disabled === true ? 'initial' : 'pointer'};
+    display:inline-block;
+    text-align:center;
+    text-decoration:unset;
+    background-color:${(props)=>props.disabled === true ? 'var(--color-primary-400)' : 'var(--color-primary-600)'};
+    color:#fff;
+    font-size:14px;
+    border-radius:500px;
+    min-height:24px;
+    line-height:44px;
+    height:44px;
+    width: ${(props)=>(props.width? `${props.width}px` : '100%')};
+    transition: all 0.2s;
+
+    &:active {
+        background-color:var(--color-primary-800);
+    }
+    `
+
+export default function DefaultButton({width,text,disabled,onClick,href} : DefaultButtonProps) {
+    if(href) {
+        return (
+            <DefaultBtn as="a"
+            width={width}
+            href={href}
+            >{text}</DefaultBtn>
+        )
+    } else {
+        return (
+            <DefaultBtn
+            width={width}
+            disabled={disabled}
+            onClick={onClick}
+            >{text}</DefaultBtn>
+        )
+    }
+
+}


### PR DESCRIPTION
공통 버튼 컴포넌트입니다

```
interface DefaultButtonProps {
    text: string;
    width?: number;
    disabled?: boolean;
    onClick?:()=>void;
    href?:string;
}
```

- text(필수) : 버튼 내부 텍스트
- width : 버튼 넓이, px단위로 숫자만 전달 가능, 미입력 시 자동으로 100% 설정
- disabled : true일 때 버튼 배경 컬러, pointer 가 변경
- onclick : 버튼일 경우 정의, 호출 컴포넌트에서 정의 가능
- href : a일 경우 정의


**호출 컴포넌트 예시**
```
function App() {

  const handleConsole = ():void => {
    console.log('hihi')
  }

  return <>
    <DefaultButton
    width={150}
    text={'팔로우'}
    disabled={false}
    onClick={()=>handleConsole()}
    />
    <DefaultButton
    width={150}
    text={'팔로우'}
    href={'https://google.com'}
    />
  </>;
}
```

윗부분이 button 컴포넌트, 아래부분이 a 링크입니다.


