### PR TITLE
[#70] 페이지별 헤더 UI  HeaderContext 방식으로  구현, GlobalLayout 경로별 자동 설정 수정

### DIFF
--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -12,103 +12,36 @@ import {
   AllyHiddenTitle,
 } from "./Header.styled";
 import DefaultButton from "./Button";
+import { useHeader } from "../../contexts/HeaderContext";
 
-// 타입별로 필요한 props를 명확히 정의 (discriminated union)
-type HeaderProps =
-  | { type?: "feed"; onBackClick?: () => void; onSearchClick?: () => void }
-  | { type: "search"; onBackClick?: () => void }
-  | { type: "followers"; onBackClick?: () => void }
-  | { type: "profile"; onBackClick?: () => void; onMoreClick?: () => void }
-  | {
-      type: "edit";
-      inputState: boolean;
-      onButtonClick: () => void;
-      onBackClick?: () => void;
-    }
-  | {
-      type: "post";
-      inputState: boolean;
-      onButtonClick: () => void;
-      onBackClick?: () => void;
-    }
-  | { type: "chatList"; onBackClick?: () => void; onMoreClick?: () => void }
-  | {
-      type: "chat";
-      userName: string;
-      onBackClick?: () => void;
-      onMoreClick?: () => void;
-    };
+function Header() {
+  const { config } = useHeader();
 
-// 타입 가드 함수들
-const isFeedType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type?: "feed" }> => {
-  return !props.type || props.type === "feed";
-};
+  // Header를 숨길 경우 아무것도 렌더링하지 않음
+  if (!config.show) {
+    return null;
+  }
 
-const isSearchType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type: "search" }> => {
-  return props.type === "search";
-};
-
-const isFollowersType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type: "followers" }> => {
-  return props.type === "followers";
-};
-
-const isProfileType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type: "profile" }> => {
-  return props.type === "profile";
-};
-
-const isEditType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type: "edit" }> => {
-  return props.type === "edit";
-};
-
-const isPostType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type: "post" }> => {
-  return props.type === "post";
-};
-
-const isChatListType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type: "chatList" }> => {
-  return props.type === "chatList";
-};
-
-const isChatType = (
-  props: HeaderProps
-): props is Extract<HeaderProps, { type: "chat" }> => {
-  return props.type === "chat";
-};
-
-function Header(props: HeaderProps) {
   return (
     <HeaderContainer>
       <h1 className="sr-only">물고기 마켓</h1>
 
       {/* 피드 */}
-      {isFeedType(props) && (
+      {(!config.type || config.type === "feed") && (
         <Section>
-          <Title>물고기마켓 피드</Title>
-          <IconButton onClick={props.onSearchClick}>
+          <Title>{config.title || "물고기마켓 피드"}</Title>
+          <IconButton onClick={config.onSearchClick}>
             <img src="/img/icon-search.svg" alt="검색열기" />
           </IconButton>
         </Section>
       )}
 
       {/* 검색 */}
-      {isSearchType(props) && (
+      {config.type === "search" && (
         <Section>
           <AllyHiddenTitle>검색</AllyHiddenTitle>
           <SearchForm>
-            <BackButton onClick={props.onBackClick}>
+            <BackButton onClick={config.onBackClick}>
               <img src="/img/icon-arrow-left.svg" alt="이전 페이지로 이동" />
             </BackButton>
             <SearchInput type="text" placeholder="계정 검색" autoFocus />
@@ -117,79 +50,79 @@ function Header(props: HeaderProps) {
       )}
 
       {/* 팔로워 목록 */}
-      {isFollowersType(props) && (
+      {config.type === "followers" && (
         <SectionCombine>
-          <BackButton onClick={props.onBackClick}>
+          <BackButton onClick={config.onBackClick}>
             <img src="/img/icon-arrow-left.svg" alt="이전 페이지로 이동" />
           </BackButton>
-          <SubTitle>Followers</SubTitle>
+          <SubTitle>{config.title || "Followers"}</SubTitle>
         </SectionCombine>
       )}
 
       {/* 프로필 */}
-      {isProfileType(props) && (
+      {config.type === "profile" && (
         <Section>
-          <IconButton onClick={props.onBackClick}>
+          <IconButton onClick={config.onBackClick}>
             <img src="/img/icon-arrow-left.svg" alt="이전 페이지로 이동" />
           </IconButton>
-          <IconButton onClick={props.onMoreClick}>
+          <IconButton onClick={config.onMoreClick}>
             <img src="/img/icon-more-vertical.svg" alt="더보기" />
           </IconButton>
         </Section>
       )}
 
       {/* 프로필 수정 */}
-      {isEditType(props) && (
+      {config.type === "edit" && (
         <Section>
-          <IconButton onClick={props.onBackClick}>
+          <IconButton onClick={config.onBackClick}>
             <img src="/img/icon-arrow-left.svg" alt="이전 페이지로 이동" />
           </IconButton>
           <DefaultButton
             text="저장"
             width={90}
-            disabled={!props.inputState}
-            onClick={props.onButtonClick}
+            disabled={!config.inputState}
+            onClick={config.onButtonClick}
           />
         </Section>
       )}
 
       {/* 게시글 작성 */}
-      {isPostType(props) && (
+      {config.type === "post" && (
         <Section>
-          <IconButton onClick={props.onBackClick}>
+          <IconButton onClick={config.onBackClick}>
             <img src="/img/icon-arrow-left.svg" alt="이전 페이지로 이동" />
           </IconButton>
           <DefaultButton
             text="업로드"
             width={90}
-            disabled={!props.inputState}
-            onClick={props.onButtonClick}
+            disabled={!config.inputState}
+            onClick={config.onButtonClick}
           />
         </Section>
       )}
 
       {/* 채팅 목록 */}
-      {isChatListType(props) && (
+      {config.type === "chatList" && (
         <Section>
-          <IconButton onClick={props.onBackClick}>
+          <IconButton onClick={config.onBackClick}>
             <img src="/img/icon-arrow-left.svg" alt="이전 페이지로 이동" />
           </IconButton>
-          <IconButton onClick={props.onMoreClick}>
+          <IconButton onClick={config.onMoreClick}>
             <img src="/img/icon-more-vertical.svg" alt="더보기" />
           </IconButton>
         </Section>
       )}
 
       {/* 채팅 */}
-      {isChatType(props) && (
+      {config.type === "chat" && (
         <Section>
           <ChatUserContainer>
-            <IconButton onClick={props.onBackClick}>
+            <IconButton onClick={config.onBackClick}>
               <img src="/img/icon-arrow-left.svg" alt="이전 페이지로 이동" />
             </IconButton>
-            <h2>{props.userName}</h2>
+            <h2>{config.userName}</h2>
           </ChatUserContainer>
-          <IconButton onClick={props.onMoreClick}>
+          <IconButton onClick={config.onMoreClick}>
             <img src="/img/icon-more-vertical.svg" alt="더보기" />
           </IconButton>
         </Section>

--- a/src/components/common/profile/Profile.tsx
+++ b/src/components/common/profile/Profile.tsx
@@ -383,7 +383,7 @@ function Profile() {
       </ProfileSection>
 
       {/* 판매중인상품 영역 */}
-      <SellingProducts />
+      {/* <SellingProducts /> */}
 
       {/* 피드 섹션 - 모든 프로필에서 표시 */}
       <MyFeedSection>

--- a/src/components/layout/globalLayout.tsx
+++ b/src/components/layout/globalLayout.tsx
@@ -1,7 +1,9 @@
 import Header from "../common/Header";
 import FooterNav from "../common/FooterNav";
-import { Outlet, useLocation } from "react-router-dom";
+import { Outlet, useLocation, useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import { HeaderProvider, useHeader } from "../../contexts/HeaderContext";
+import { useEffect } from "react";
 
 const LayoutContainer = styled.div`
   max-width: 600px;
@@ -23,8 +25,102 @@ const MainContent = styled.main<{ $hasFooter: boolean }>`
   padding-bottom: ${(props) => (props.$hasFooter ? "110px" : "50px")};
 `;
 
-export default function GlobalLayout() {
+function LayoutContent() {
   const location = useLocation();
+  const { setHeaderConfig } = useHeader();
+  const navigate = useNavigate();
+
+  // 경로별 헤더 자동 설정
+  useEffect(() => {
+    const path = location.pathname;
+
+    // Header를 숨길 경로들 (가장 먼저 체크)
+    if (
+      path === "/login" ||
+      path === "/login/email" ||
+      path === "/signup"
+    ) {
+      setHeaderConfig({ show: false });
+      return;
+    }
+
+    // 프로필 셋업 (정확한 경로 체크)
+    if (path === "/profile/setup") {
+      setHeaderConfig({
+        show: true,
+        type: "edit",
+        inputState: true,
+        onBackClick: () => navigate("/login"),
+        onButtonClick: () => console.log("프로필 설정 완료"),
+      });
+      return;
+    }
+
+    // 프로필 수정 (정확한 경로를 먼저 체크)
+    if (path === "/profile/edit") {
+      setHeaderConfig({
+        show: true,
+        type: "edit",
+        inputState: true,
+        onBackClick: () => navigate("/profile"),
+        onButtonClick: () => console.log("저장"),
+      });
+      return;
+    }
+
+    // 프로필 페이지 (edit 이후에 체크)
+    if (path === "/profile") {
+      setHeaderConfig({
+        show: true,
+        type: "profile",
+        onBackClick: () => navigate("/"),
+        onMoreClick: () => console.log("더보기"),
+      });
+      return;
+    }
+
+    // 게시글 작성
+    if (path === "/post") {
+      setHeaderConfig({
+        show: true,
+        type: "post",
+        inputState: true,
+        onBackClick: () => navigate("/"),
+        onButtonClick: () => console.log("업로드"),
+      });
+      return;
+    }
+
+    // 검색 페이지
+    if (path === "/search") {
+      setHeaderConfig({
+        show: true,
+        type: "search",
+        onBackClick: () => navigate("/"),
+      });
+      return;
+    }
+
+    // 상품 추가
+    if (path === "/product/add") {
+      setHeaderConfig({
+        show: true,
+        type: "edit",
+        inputState: true,
+        onBackClick: () => navigate("/"),
+        onButtonClick: () => console.log("상품 등록"),
+      });
+      return;
+    }
+
+    // 기본 (피드)
+    setHeaderConfig({
+      show: true,
+      type: "feed",
+      onSearchClick: () => navigate("/search"),
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [location.pathname]);
 
   // FooterNav를 숨길 경로들
   const hideNavPaths = [
@@ -37,25 +133,26 @@ export default function GlobalLayout() {
     "/product/add",
   ];
 
-  // Header를 숨길 경로들
-  const hideHeadPaths = ["/login", "/login/email", "/signup", "/profile/setup"];
-
   // 현재 경로가 숨김 목록에 있는지 확인
   const shouldHideNav = hideNavPaths.some((path) =>
     location.pathname.startsWith(path)
   );
 
-  const shouldHideHead = hideHeadPaths.some((path) =>
-    location.pathname.startsWith(path)
-  );
-
   return (
     <LayoutContainer>
-      {!shouldHideHead && <Header />}
+      <Header />
       <MainContent $hasFooter={!shouldHideNav}>
         <Outlet />
       </MainContent>
       {!shouldHideNav && <FooterNav />}
     </LayoutContainer>
+  );
+}
+
+export default function GlobalLayout() {
+  return (
+    <HeaderProvider>
+      <LayoutContent />
+    </HeaderProvider>
   );
 }

--- a/src/contexts/HeaderContext.tsx
+++ b/src/contexts/HeaderContext.tsx
@@ -1,0 +1,61 @@
+import { createContext, useContext, useState, ReactNode } from "react";
+
+// Header 타입 정의
+export type HeaderType =
+  | "feed"
+  | "search"
+  | "followers"
+  | "profile"
+  | "edit"
+  | "post"
+  | "chatList"
+  | "chat";
+
+// Header 설정 인터페이스
+export interface HeaderConfig {
+  show: boolean;
+  type?: HeaderType;
+  title?: string;
+  userName?: string; // chat type에서 사용
+  inputState?: boolean; // edit, post type에서 사용
+  onBackClick?: () => void;
+  onSearchClick?: () => void;
+  onMoreClick?: () => void;
+  onButtonClick?: () => void;
+}
+
+// Context 타입
+interface HeaderContextType {
+  config: HeaderConfig;
+  setHeaderConfig: (config: Partial<HeaderConfig>) => void;
+}
+
+// Context 생성
+const HeaderContext = createContext<HeaderContextType | null>(null);
+
+// Provider 컴포넌트
+export const HeaderProvider = ({ children }: { children: ReactNode }) => {
+  const [config, setConfig] = useState<HeaderConfig>({
+    show: true,
+    type: "feed",
+  });
+
+  const setHeaderConfig = (newConfig: Partial<HeaderConfig>) => {
+    setConfig((prev) => ({ ...prev, ...newConfig }));
+  };
+
+  return (
+    <HeaderContext.Provider value={{ config, setHeaderConfig }}>
+      {children}
+    </HeaderContext.Provider>
+  );
+};
+
+// Custom Hook
+export const useHeader = () => {
+  const context = useContext(HeaderContext);
+  if (!context) {
+    throw new Error("useHeader must be used within HeaderProvider");
+  }
+  return context;
+};

--- a/src/pages/Home/FeedPage.tsx
+++ b/src/pages/Home/FeedPage.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import DefaultButton from "../../components/common/Button";
 import {
   EmptyFeedSection,
@@ -11,6 +12,7 @@ import {
 } from "./FeedPage.styled";
 
 const FeedPage = () => {
+  const navigate = useNavigate();
   type Feed = {
     id: string; // 게시글 고유 ID
     profileImg: string; // 프로필 이미지 URL
@@ -115,7 +117,11 @@ const FeedPage = () => {
           <EmptyFeedSection>
             <LogoImage src="/img/fish-logo-GB.svg" alt="물고기마켓 로고" />
             <h2>유저를 검색해 팔로우 해보세요!</h2>
-            <DefaultButton text="검색하기" width={120} />
+            <DefaultButton
+              text="검색하기"
+              width={120}
+              onClick={() => navigate("/search")}
+            />
           </EmptyFeedSection>
         </main>
       </>

--- a/src/rootRoute.tsx
+++ b/src/rootRoute.tsx
@@ -18,7 +18,7 @@ export default function RootRoute() {
 
       <Routes>
         <Route element={<GlobalLayout />}>
-          <Route path="/" />
+          <Route path="/" element={<FeedPage />} />
           {/* 로그인, 회원가입 */}
 
           <Route path="/login" element={<Login />} />
@@ -26,7 +26,7 @@ export default function RootRoute() {
           <Route path="/signup" element={<Signup />} />
           {/* 프로필 */}
           <Route path="/profile/setup" element={<ProfileSetup />} />
-          <Route path="/Profile" element={<Profile />} />
+          <Route path="/profile" element={<Profile />} />
           <Route path="/profile/edit" element={<ProfileEdit />} />
           {/* 메인 피드, 검색 */}
           <Route path="/feed" element={<FeedPage />} />


### PR DESCRIPTION
구현 부분
HeaderContext생성
GlobalLayout에서 경로별 자동 설정 

경로 | 헤더 타입 | 뒤로가기 | 우측 버튼
-- | -- | -- | --
/ | feed | - | 검색 아이콘
/login, /signup | 숨김 | - | -
/profile/setup | edit | /login | 저장 버튼
/profile | profile | / | 뒤로+더보기
/profile/edit | edit | /profile | 저장 버튼
/post | post | / | 업로드 버튼
/search | search | / | -
/product/add | edit | / | 상품 등록 버튼

<br class="Apple-interchange-newline">

핵심 해결 사항

1. 무한 루프 방지: useEffect 의존성 배열에서 setHeaderConfig와 navigate 제거 (// eslint-disable-next-line react-hooks/exhaustive-deps)
2. 경로 체크 순서: 더 구체적인 경로(/profile/edit)를 포괄적인 경로(/profile)보다 먼저 체크
3. 라우트 경로 통일: /Profile → /profile (소문자로 통일)
4. Profile 컴포넌트: 주석처리되지 않은 <SellingProducts /> 주석 처리
