### PR TITLE
fix/auth timing issue

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,25 +1,35 @@
+import { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 import RootRoute from "./rootRoute";
 import { SearchProvider } from "./contexts/SearchContext";
-import { AuthProvider } from "./contexts/AuthContext";
+// import { AuthProvider } from "./contexts/AuthContext";
+import { useAuthStore } from "./contexts/useAuthStore";
 import { ToastContainer } from "react-toastify";
 import Toast from "./components/common/modal/Toast";
 import Pusher from "pusher-js";
-export const pusher = new Pusher('25b10e3b7afa8175af9e', {
-  cluster: 'ap3', // 도쿄
+export const pusher = new Pusher("25b10e3b7afa8175af9e", {
+  cluster: "ap3", // 도쿄
 });
 
 function App() {
+  const refreshUser = useAuthStore((s) => s.refreshUser);
+  // const isLoading = useAuthStore((s) => s.isLoading);
+
+  useEffect(() => {
+    // 앱 시작 시 한 번만 수행
+    refreshUser();
+  }, [refreshUser]);
+
   return (
-    <AuthProvider>
-      <BrowserRouter>
-        <SearchProvider>
-            <ToastContainer />
-            <Toast />
-          <RootRoute />
-        </SearchProvider>
-      </BrowserRouter>
-    </AuthProvider>
+    // <AuthProvider>
+    <BrowserRouter>
+      <SearchProvider>
+        <ToastContainer />
+        <Toast />
+        <RootRoute />
+      </SearchProvider>
+    </BrowserRouter>
+    // </AuthProvider>
   );
 }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { BrowserRouter } from "react-router-dom";
 import RootRoute from "./rootRoute";
 import { SearchProvider } from "./contexts/SearchContext";
-// import { AuthProvider } from "./contexts/AuthContext";
 import { useAuthStore } from "./contexts/useAuthStore";
 import { ToastContainer } from "react-toastify";
 import Toast from "./components/common/modal/Toast";
@@ -13,7 +12,6 @@ export const pusher = new Pusher("25b10e3b7afa8175af9e", {
 
 function App() {
   const refreshUser = useAuthStore((s) => s.refreshUser);
-  // const isLoading = useAuthStore((s) => s.isLoading);
 
   useEffect(() => {
     // 앱 시작 시 한 번만 수행
@@ -21,7 +19,6 @@ function App() {
   }, [refreshUser]);
 
   return (
-    // <AuthProvider>
     <BrowserRouter>
       <SearchProvider>
         <ToastContainer />
@@ -29,7 +26,6 @@ function App() {
         <RootRoute />
       </SearchProvider>
     </BrowserRouter>
-    // </AuthProvider>
   );
 }
 

--- a/src/components/common/auth/AuthForm.tsx
+++ b/src/components/common/auth/AuthForm.tsx
@@ -101,7 +101,7 @@ export default function AuthForm({
     try {
       await onSubmit(e);
     } catch (error) {
-      console.error("Form submission error:", error);
+      console.error("인증 폼 제출 에러: ", error);
     }
   };
 

--- a/src/components/common/auth/AuthForm.tsx
+++ b/src/components/common/auth/AuthForm.tsx
@@ -98,11 +98,13 @@ export default function AuthForm({
       return;
     }
 
-    try {
-      await onSubmit(e);
-    } catch (error) {
-      console.error("인증 폼 제출 에러: ", error);
-    }
+    onSubmit(e);
+
+    // try {
+    //   await onSubmit(e);
+    // } catch (error) {
+    //   console.error("인증 폼 제출 에러: ", error);
+    // }
   };
 
   const isFormValid = useMemo(() => {

--- a/src/components/common/form/CreateForm.tsx
+++ b/src/components/common/form/CreateForm.tsx
@@ -173,8 +173,7 @@ function CreateFormInner<T extends FormData>(
         const error = await field.validator(formValues[field.name]);
         // 계정ID 제출 시 검사 로그
         if (field.name === "accountname") {
-          console.log("[계정ID 제출] 입력값:", formValues[field.name]);
-          console.log("[계정ID 제출] 에러 메시지:", error);
+          console.log("계정ID 제출 에러 메시지:", error);
         }
         if (error) newErrors[field.name] = error;
       }
@@ -182,17 +181,13 @@ function CreateFormInner<T extends FormData>(
 
     setErrors(newErrors);
 
-    // 에러가 있으면 제출 중단 및 하단 에러 메시지 갱신
     if (Object.keys(newErrors).length > 0) {
       console.log("유효성 검사 실패:", newErrors);
-      // 하단 에러 메시지 갱신 (필요시 부모에 전달)
       return false;
     }
 
     // onSubmit 호출 - FormData 형식으로 전달
     if (onSubmit) {
-      console.log("CreateForm - 📝 폼 값:", formValues);
-
       // FormData 형식으로 변환
       const submissionData: Record<string, string | File | undefined> = {
         ...formValues,

--- a/src/components/common/modal/MoreMenu.tsx
+++ b/src/components/common/modal/MoreMenu.tsx
@@ -3,7 +3,8 @@ import styled from "styled-components";
 import BottomSheet, { SheetItem } from "./BottomSheet";
 import AlertModal from "./AlertModal";
 import { useNavigate } from "react-router-dom";
-import { useAuth } from "../../../contexts/AuthContext";
+// import { useAuth } from "../../../contexts/AuthContext";
+import { useAuthStore } from "../../../contexts/useAuthStore";
 
 interface MoreMenuProps {
   type: "profile" | "post" | "comment" | "chat" | "chatList" | "product";
@@ -78,7 +79,9 @@ export default function MoreMenu({
   const [alertType, setAlertType] = useState<
     "delete" | "deleteComment" | "logout" | "sold" | "reportPost" | null
   >(null);
-  const { logout, currentUser } = useAuth();
+  // const { logout, currentUser } = useAuth();
+  const currentUser = useAuthStore((s) => s.user);
+  const logout = useAuthStore((s) => s.logout);
 
   // 본인 여부 확인 (authorAccountname이 제공된 경우)
   const isOwner = authorAccountname
@@ -103,7 +106,6 @@ export default function MoreMenu({
   const handleDeleteComment = () => {
     closeSheet();
     setAlertType("deleteComment");
-
   };
 
   const handleLogout = () => {
@@ -119,7 +121,6 @@ export default function MoreMenu({
   const handleReportPost = () => {
     closeSheet();
     setAlertType("reportPost");
-
   };
 
   // 실제 로그아웃 처리 함수

--- a/src/components/common/modal/MoreMenu.tsx
+++ b/src/components/common/modal/MoreMenu.tsx
@@ -3,7 +3,6 @@ import styled from "styled-components";
 import BottomSheet, { SheetItem } from "./BottomSheet";
 import AlertModal from "./AlertModal";
 import { useNavigate } from "react-router-dom";
-// import { useAuth } from "../../../contexts/AuthContext";
 import { useAuthStore } from "../../../contexts/useAuthStore";
 
 interface MoreMenuProps {
@@ -79,7 +78,6 @@ export default function MoreMenu({
   const [alertType, setAlertType] = useState<
     "delete" | "deleteComment" | "logout" | "sold" | "reportPost" | null
   >(null);
-  // const { logout, currentUser } = useAuth();
   const currentUser = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
 

--- a/src/components/layout/globalLayout.tsx
+++ b/src/components/layout/globalLayout.tsx
@@ -10,8 +10,6 @@ import { useFeedData } from "../../hooks/useFeedData";
 //zustand 전역
 import { useFeedStore } from "../../contexts/useFeedStore";
 import { useAuthStore } from "../../contexts/useAuthStore";
-//인증관련 전역
-// import { useAuth } from "../../contexts/AuthContext";
 import { getToken } from "../../utils/tokenManager";
 import {
   LayoutContainer,
@@ -30,7 +28,6 @@ function LayoutContent() {
   const path = location.pathname;
   const { setHeaderConfig } = useHeader();
   const navigate = useNavigate();
-  // const { isAuthenticated, isAuthenticatedRef, currentUser } = useAuth();
   const user = useAuthStore((s) => s.user);
   const [isHeader, setIsHeader] = useState(true);
   const [isFooter, setIsFooter] = useState(true);

--- a/src/components/layout/globalLayout.tsx
+++ b/src/components/layout/globalLayout.tsx
@@ -9,21 +9,31 @@ import ScrollButton from "../common/buttons/ScrollButton";
 import { useFeedData } from "../../hooks/useFeedData";
 //zustand 전역
 import { useFeedStore } from "../../contexts/useFeedStore";
+import { useAuthStore } from "../../contexts/useAuthStore";
 //인증관련 전역
-import { useAuth } from "../../contexts/AuthContext";
+// import { useAuth } from "../../contexts/AuthContext";
 import { getToken } from "../../utils/tokenManager";
-import { LayoutContainer, MainContent, RefreshAlert, Fish1, Fish2,
-  Seashall, Coral, Drop, Drop2
- } from "./globalLayout.styled";
+import {
+  LayoutContainer,
+  MainContent,
+  RefreshAlert,
+  Fish1,
+  Fish2,
+  Seashall,
+  Coral,
+  Drop,
+  Drop2,
+} from "./globalLayout.styled";
 
 function LayoutContent() {
   const location = useLocation();
   const path = location.pathname;
   const { setHeaderConfig } = useHeader();
   const navigate = useNavigate();
-  const { isAuthenticated, isAuthenticatedRef, currentUser } = useAuth();
-  const [isHeader,setIsHeader] = useState(true)
-  const [isFooter,setIsFooter] = useState(true)
+  // const { isAuthenticated, isAuthenticatedRef, currentUser } = useAuth();
+  const user = useAuthStore((s) => s.user);
+  const [isHeader, setIsHeader] = useState(true);
+  const [isFooter, setIsFooter] = useState(true);
   //drag 이벤트
   const [pull, setPull] = useState(0);
   const startYRef = useRef(0);
@@ -36,7 +46,7 @@ function LayoutContent() {
 
   useEffect(() => {
     const path = location.pathname;
-    if (path !== '/feed') return; // main feed 페이지에서만 작동합니다
+    if (path !== "/feed") return; // main feed 페이지에서만 작동합니다
 
     const container = scrollContainerRef.current;
     if (!container) return;
@@ -50,14 +60,13 @@ function LayoutContent() {
       }
     };
 
-
     const handleDragMove = (clientY: number, preventDefault: () => void) => {
       if (!isDraggingRef.current) return;
 
       const distance = clientY - startYRef.current;
 
-      if(Math.abs(distance) > 7) {
-        hasMoveRef.current = true
+      if (Math.abs(distance) > 7) {
+        hasMoveRef.current = true;
       }
 
       if (distance > 0) {
@@ -67,12 +76,11 @@ function LayoutContent() {
         currentPullRef.current = Math.min(distance, 120);
       }
 
-      if( distance > 60) {
+      if (distance > 60) {
         preventDefault();
         isLetterRef.current = true;
       }
     };
-
 
     const handleDragEnd = () => {
       if (isDraggingRef.current) {
@@ -81,7 +89,7 @@ function LayoutContent() {
         setPull(0);
         isLetterRef.current = false;
 
-        if(hasMoveRef.current && currentPullRef.current > 80) {
+        if (hasMoveRef.current && currentPullRef.current > 80) {
           refreshFeed();
         }
 
@@ -90,11 +98,14 @@ function LayoutContent() {
     };
 
     const handleMouseDown = (e: MouseEvent) => handleDragStart(e.clientY);
-    const handleMouseMove = (e: MouseEvent) => handleDragMove(e.clientY, () => e.preventDefault());
+    const handleMouseMove = (e: MouseEvent) =>
+      handleDragMove(e.clientY, () => e.preventDefault());
     const handleMouseUp = () => handleDragEnd();
 
-    const handleTouchStart = (e: TouchEvent) => handleDragStart(e.touches[0].clientY);
-    const handleTouchMove = (e: TouchEvent) => handleDragMove(e.touches[0].clientY, () => e.preventDefault());
+    const handleTouchStart = (e: TouchEvent) =>
+      handleDragStart(e.touches[0].clientY);
+    const handleTouchMove = (e: TouchEvent) =>
+      handleDragMove(e.touches[0].clientY, () => e.preventDefault());
 
     container.addEventListener("mousedown", handleMouseDown);
     container.addEventListener("mousemove", handleMouseMove);
@@ -112,7 +123,6 @@ function LayoutContent() {
       container.removeEventListener("touchstart", handleTouchStart);
       container.removeEventListener("touchmove", handleTouchMove);
       container.removeEventListener("touchend", handleMouseUp);
-
     };
   }, []);
 
@@ -234,88 +244,108 @@ function LayoutContent() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [location.pathname]);
 
-
-  useEffect(()=>{
+  useEffect(() => {
     const token = getToken();
-    let isToken = token ? true : false;
+    const isToken = token ? true : false;
 
-    const shouldShowHeader = ():boolean => {
-      if( path === "/login" ||
+    const shouldShowHeader = (): boolean => {
+      if (
+        path === "/login" ||
         path === "/login/email" ||
         path === "/signup" ||
         path === "/profile/setup" ||
-        path === "/404" || !isToken
-      ) { return false } else { return true }
-    }
+        path === "/404" ||
+        !isToken
+      ) {
+        return false;
+      } else {
+        return true;
+      }
+    };
     const shouldShowNav = (): boolean => {
       const showNavPaths = ["/", "/feed", "/search", "/chat-list"];
 
       const isProfilePath =
         path === "/profile" || path.match(/^\/profile\/[^/]+$/);
 
-        const rew = (showNavPaths.includes(path) || !!isProfilePath)
+      const rew = showNavPaths.includes(path) || !!isProfilePath;
 
-      if(rew) {
-        if(isToken) return true
-        else return false
+      if (rew) {
+        if (isToken) return true;
+        else return false;
       } else {
-        return false
+        return false;
       }
     };
 
-    setIsHeader(shouldShowHeader())
-    setIsFooter(shouldShowNav())
-
-  },[currentUser])
-
-
+    setIsHeader(shouldShowHeader());
+    setIsFooter(shouldShowNav());
+  }, [path, user]);
 
   const isProfilePage =
     location.pathname === "/profile" ||
     !!location.pathname.match(/^\/profile\/[^/]+$/);
 
-    const isPostDetailPage = location.pathname.match(/^\/post\/[^/]+$/);
+  const isPostDetailPage = location.pathname.match(/^\/post\/[^/]+$/);
 
-    return (
-      <>
-        <LayoutContainer $isProfile={isProfilePage}>
-          {isHeader && <Header />}
-        {pull !==0 && (
+  return (
+    <>
+      <LayoutContainer $isProfile={isProfilePage}>
+        {isHeader && <Header />}
+        {pull !== 0 && (
           <RefreshAlert $letter={isLetterRef.current} $height={pull}>
-            <div style={{ position: 'relative' }}>
-              <Fish1 src="/img/fish-character.png" $transform={pull} alt="물고기"/>
-              <Seashall src="/img/seashall-character.png" $transform={pull} alt="조개껍질"></Seashall>
-              <p>땡겨서 <span>피쉬마켓</span> 새로고침</p>
-              <Fish2 src="/img/fish-character.png" $transform={pull} alt="물고기"/>
-              <Coral src="/img/coral-character.png" $transform={pull} alt="산호"/>
-              <Drop src="/img/drop.png" $transform={pull} alt="물방울"/>
-              <Drop2 src="/img/drop.png" $transform={pull} alt="물방울"/>
+            <div style={{ position: "relative" }}>
+              <Fish1
+                src="/img/fish-character.png"
+                $transform={pull}
+                alt="물고기"
+              />
+              <Seashall
+                src="/img/seashall-character.png"
+                $transform={pull}
+                alt="조개껍질"
+              ></Seashall>
+              <p>
+                땡겨서 <span>피쉬마켓</span> 새로고침
+              </p>
+              <Fish2
+                src="/img/fish-character.png"
+                $transform={pull}
+                alt="물고기"
+              />
+              <Coral
+                src="/img/coral-character.png"
+                $transform={pull}
+                alt="산호"
+              />
+              <Drop src="/img/drop.png" $transform={pull} alt="물방울" />
+              <Drop2 src="/img/drop.png" $transform={pull} alt="물방울" />
             </div>
           </RefreshAlert>
-          )}
-          <AnimatePresence mode="wait">
-            <MainContent
-              key={location.pathname}
-              $hasFooter={isFooter}
-              $isProfile={isProfilePage}
-              $isPostDetail={!!isPostDetailPage}
-              as={motion.main}
-              initial={{ opacity: 0 }}
-              animate={{ opacity: 1 }}
-              transition={{ duration: 0.26, ease: "easeOut" }}
-              ref={scrollContainerRef}
-              isPadding={location.pathname}
-            >
-              <Outlet />
-            </MainContent>
-          </AnimatePresence>
-          {isFooter && <FooterNav />}
-        </LayoutContainer>
-        {/* 플로팅 챗봇 - position: fixed로 전역에 표시 */}
-        <FloatingChatbot />
-        <ScrollButton scrollContainerRef={scrollContainerRef}></ScrollButton>
-      </>
-    );
+        )}
+        <AnimatePresence mode="wait">
+          <MainContent
+            key={location.pathname}
+            $hasFooter={isFooter}
+            $isProfile={isProfilePage}
+            $isPostDetail={!!isPostDetailPage}
+            as={motion.main}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            transition={{ duration: 0.26, ease: "easeOut" }}
+            ref={scrollContainerRef}
+            isPadding={location.pathname}
+          >
+            <Outlet />
+          </MainContent>
+        </AnimatePresence>
+        {isFooter && <FooterNav />}
+      </LayoutContainer>
+      {/* 플로팅 챗봇 - position: fixed로 전역에 표시 */}
+      <FloatingChatbot />
+      <ScrollButton scrollContainerRef={scrollContainerRef}></ScrollButton>
+    </>
+  );
 }
 
 export default function GlobalLayout() {

--- a/src/contexts/useAuthStore.ts
+++ b/src/contexts/useAuthStore.ts
@@ -47,6 +47,7 @@ export const useAuthStore = create<State>()(
             } catch (err) {
               console.warn("브로드캐스트 로그아웃 중 토큰 제거 실패:", err);
             }
+            window.location.reload();
           }
           if (type === "login") {
             set({ token: ev.data.token });
@@ -54,7 +55,6 @@ export const useAuthStore = create<State>()(
         };
       } catch (err) {
         console.warn("BroadcastChannel을 사용할 수 없습니다:", err);
-        // bc = null;
       }
 
       return {

--- a/src/contexts/useAuthStore.ts
+++ b/src/contexts/useAuthStore.ts
@@ -1,0 +1,250 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import {
+  saveToken,
+  getToken,
+  removeToken,
+  getAuthHeaders,
+} from "../utils/tokenManager";
+import { AuthResponse } from "../services/authService";
+
+const BASE_URL = "https://dev.wenivops.co.kr/services/mandarin";
+const DEFAULT_PROFILE_IMG = "/img/empty-profile.png";
+
+// 사용자 타입
+export interface AuthUser {
+  _id: string;
+  username: string;
+  accountname: string;
+  email: string;
+  image: string;
+  intro: string;
+}
+
+type State = {
+  user: AuthUser | null;
+  token: string | null;
+  isLoading: boolean;
+  error: string | null;
+  lastFetchedAt: number | null;
+
+  // actions: 유저, 토큰 저장
+  setUser: (u: AuthUser | null) => void;
+  setToken: (t: string | null) => void;
+
+  signup: (email: string, password: string) => Promise<AuthUser | null>;
+  login: (email: string, password: string) => Promise<AuthUser | null>;
+  logout: () => void;
+  refreshUser: () => Promise<AuthUser | null>;
+  updateUser: (parital: Partial<AuthUser>) => void;
+};
+
+export const useAuthStore = create<State>()(
+  persist(
+    (set, get) => {
+      try {
+        const bc = new BroadcastChannel("auth");
+        bc.onmessage = (ev) => {
+          const { type } = ev.data || {};
+          if (type === "logout") {
+            set({ user: null, token: null });
+            try {
+              removeToken();
+            } catch (err) {
+              console.warn("removeToken failed during broadcast logout:", err);
+            }
+          }
+          if (type === "login") {
+            set({ token: ev.data.token });
+          }
+        };
+      } catch (err) {
+        console.warn("BroadcastChannel unavailable:", err);
+        // bc = null;
+      }
+
+      return {
+        user: null,
+        token: getToken() || null,
+        isLoading: false,
+        error: null,
+        lastFetchedAt: null,
+
+        setUser: (u) => set({ user: u }),
+        setToken: (t) => {
+          if (t) {
+            try {
+              saveToken(t);
+            } catch (err) {
+              console.error("saveToken failed:", err);
+            }
+            try {
+              new BroadcastChannel("auth").postMessage({
+                type: "login",
+                token: t,
+              });
+            } catch (err) {
+              console.warn("BroadcastChannel postMessage(login) failed:", err);
+            }
+          } else {
+            try {
+              removeToken();
+            } catch (err) {
+              console.error("removeToken failed:", err);
+            }
+            try {
+              new BroadcastChannel("auth").postMessage({ type: "logout " });
+            } catch (err) {
+              console.warn("BroadcastChannel postMessage(logout) failed:", err);
+            }
+          }
+          set({ token: t });
+        },
+
+        // 회원가입
+        signup: async (email: string, password: string) => {
+          set({ isLoading: true, error: null });
+          try {
+            const timestamp = Date.now();
+            const tempUsername = `user_${timestamp}`;
+            const tempAccountname = `account_${timestamp}`;
+
+            const res = await fetch(`${BASE_URL}/user`, {
+              method: "POST",
+              headers: {
+                "Content-Type": "application/json",
+              },
+              body: JSON.stringify({
+                user: {
+                  username: tempUsername,
+                  email,
+                  password,
+                  accountname: tempAccountname,
+                  intro: "",
+                  image: DEFAULT_PROFILE_IMG,
+                },
+              }),
+            });
+
+            const data: AuthResponse = await res.json();
+            if (!res.ok) {
+              const msg = data.message || "회원가입 실패";
+              throw new Error(msg);
+            }
+
+            // 회원가입 뒤 자동 로그인 토큰
+            const loginRes = await fetch(`${BASE_URL}/user/login`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ user: { email, password } }),
+            });
+            const loginData = await loginRes.json();
+            if (!loginRes.ok) {
+              throw new Error(loginData.message || "자동 로그인 실패");
+            }
+
+            // 토큰 저장
+            const token = loginData.token;
+            get().setToken(token);
+
+            // 유저 정보 갱신
+            const user = await get().refreshUser();
+            set({ isLoading: false });
+            return user;
+          } catch (err: unknown) {
+            const errMsg = err instanceof Error ? err.message : "signup error";
+            set({ isLoading: false, error: errMsg });
+            throw err;
+          }
+        },
+
+        // 이메일 로그인
+        login: async (email: string, password: string) => {
+          set({ isLoading: true, error: null });
+          try {
+            const res = await fetch(`${BASE_URL}/user/login`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body: JSON.stringify({ user: { email, password } }),
+            });
+            const data = await res.json();
+            if (!res.ok) {
+              throw new Error(data.message || "로그인 실패");
+            }
+
+            const token = data.token;
+            get().setToken(token);
+
+            // 토큰 저장 후 즉시 사용자 정보 가져오기
+            const user = await get().refreshUser();
+            set({ isLoading: false });
+            return user;
+          } catch (err: unknown) {
+            const errMsg = err instanceof Error ? err.message : "login error";
+            set({ isLoading: false, error: errMsg });
+            throw err;
+          }
+        },
+
+        logout: () => {
+          try {
+            removeToken();
+          } catch (err) {
+            console.error("removeToken failed in logout:", err);
+          }
+          try {
+            new BroadcastChannel("auth").postMessage({ type: "logout" });
+          } catch (err) {
+            console.warn(
+              "BroadcastChannel postMessage(logout) failed in logout:",
+              err
+            );
+          }
+          set({ user: null, token: null });
+        },
+
+        refreshUser: async () => {
+          set({ isLoading: true, error: null });
+          try {
+            const token = getToken();
+            if (!token) {
+              set({ isLoading: false, user: null });
+              return null;
+            }
+            const res = await fetch(`${BASE_URL}/user/myinfo`, {
+              method: "GET",
+              headers: getAuthHeaders(),
+            });
+            const payload = await res.json();
+            if (!res.ok) {
+              removeToken();
+              set({ user: null, token: null, isLoading: false });
+              return null;
+            }
+            const user = payload.user as AuthUser;
+            set({ user, lastFetchedAt: Date.now(), isLoading: false });
+            return user;
+          } catch (err: unknown) {
+            const errMsg = err instanceof Error ? err.message : "refresh error";
+            set({
+              user: null,
+              isLoading: false,
+              error: errMsg,
+            });
+            return null;
+          }
+        },
+
+        updateUser: (partial) => {
+          const u = get().user;
+          if (!u) return;
+          set({ user: { ...u, ...partial } as AuthUser });
+        },
+      };
+    },
+    {
+      name: "auth-storage", //localStorage key
+      partialize: (state) => ({ user: state.user }), // 보안을 위해 토큰을 persist에서 제외
+    }
+  )
+);

--- a/src/contexts/useAuthStore.ts
+++ b/src/contexts/useAuthStore.ts
@@ -1,14 +1,8 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
-import {
-  saveToken,
-  getToken,
-  removeToken,
-  getAuthHeaders,
-} from "../utils/tokenManager";
-import { AuthResponse } from "../services/authService";
+import { saveToken, getToken, removeToken } from "../utils/tokenManager";
+import * as auth from "../services/authService";
 
-const BASE_URL = "https://dev.wenivops.co.kr/services/mandarin";
 const DEFAULT_PROFILE_IMG = "/img/empty-profile.png";
 
 // 사용자 타입
@@ -51,7 +45,7 @@ export const useAuthStore = create<State>()(
             try {
               removeToken();
             } catch (err) {
-              console.warn("removeToken failed during broadcast logout:", err);
+              console.warn("브로드캐스트 로그아웃 중 토큰 제거 실패:", err);
             }
           }
           if (type === "login") {
@@ -59,7 +53,7 @@ export const useAuthStore = create<State>()(
           }
         };
       } catch (err) {
-        console.warn("BroadcastChannel unavailable:", err);
+        console.warn("BroadcastChannel을 사용할 수 없습니다:", err);
         // bc = null;
       }
 
@@ -76,7 +70,7 @@ export const useAuthStore = create<State>()(
             try {
               saveToken(t);
             } catch (err) {
-              console.error("saveToken failed:", err);
+              console.error("토큰 저장 실패:", err);
             }
             try {
               new BroadcastChannel("auth").postMessage({
@@ -84,18 +78,18 @@ export const useAuthStore = create<State>()(
                 token: t,
               });
             } catch (err) {
-              console.warn("BroadcastChannel postMessage(login) failed:", err);
+              console.warn("로그인 브로드캐스트 전송 실패:", err);
             }
           } else {
             try {
               removeToken();
             } catch (err) {
-              console.error("removeToken failed:", err);
+              console.error("토큰 제거 실패:", err);
             }
             try {
-              new BroadcastChannel("auth").postMessage({ type: "logout " });
+              new BroadcastChannel("auth").postMessage({ type: "logout" });
             } catch (err) {
-              console.warn("BroadcastChannel postMessage(logout) failed:", err);
+              console.warn("로그아웃 브로드캐스트 전송 실패:", err);
             }
           }
           set({ token: t });
@@ -106,103 +100,73 @@ export const useAuthStore = create<State>()(
           set({ isLoading: true, error: null });
           try {
             const timestamp = Date.now();
-            const tempUsername = `user_${timestamp}`;
-            const tempAccountname = `account_${timestamp}`;
+            const payload = {
+              username: `user_${timestamp}`,
+              email,
+              password,
+              accountname: `account_${timestamp}`,
+              intro: "",
+              image: DEFAULT_PROFILE_IMG,
+            };
 
-            const res = await fetch(`${BASE_URL}/user`, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-              },
-              body: JSON.stringify({
-                user: {
-                  username: tempUsername,
-                  email,
-                  password,
-                  accountname: tempAccountname,
-                  intro: "",
-                  image: DEFAULT_PROFILE_IMG,
-                },
-              }),
-            });
+            await auth.signup(payload);
 
-            const data: AuthResponse = await res.json();
-            if (!res.ok) {
-              const msg = data.message || "회원가입 실패";
-              throw new Error(msg);
-            }
-
-            // 회원가입 뒤 자동 로그인 토큰
-            const loginRes = await fetch(`${BASE_URL}/user/login`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ user: { email, password } }),
-            });
-            const loginData = await loginRes.json();
-            if (!loginRes.ok) {
-              throw new Error(loginData.message || "자동 로그인 실패");
-            }
+            // 회원가입 뒤 자동 로그인
+            const loginData = await auth.login(email, password);
 
             // 토큰 저장
             const token = loginData.token;
             get().setToken(token);
 
             // 유저 정보 갱신
-            const user = await get().refreshUser();
+            const myInfo = await auth.getMyInfo();
+            const user = myInfo.user as AuthUser;
             set({ isLoading: false });
             return user;
-          } catch (err: unknown) {
-            const errMsg = err instanceof Error ? err.message : "signup error";
+          } catch (err: any) {
+            const errMsg = err?.message || "회원가입 중 오류가 발생했습니다.";
             set({ isLoading: false, error: errMsg });
             throw err;
           }
         },
 
-        // 이메일 로그인
+        // 로그인
         login: async (email: string, password: string) => {
           set({ isLoading: true, error: null });
           try {
-            const res = await fetch(`${BASE_URL}/user/login`, {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({ user: { email, password } }),
-            });
-            const data = await res.json();
-            if (!res.ok) {
-              throw new Error(data.message || "로그인 실패");
-            }
-
+            const data = await auth.login(email, password);
             const token = data.token;
             get().setToken(token);
 
             // 토큰 저장 후 즉시 사용자 정보 가져오기
-            const user = await get().refreshUser();
-            set({ isLoading: false });
+            const myInfo = await auth.getMyInfo();
+            const user = myInfo.user as AuthUser;
+
+            set({ user, isLoading: false });
             return user;
-          } catch (err: unknown) {
-            const errMsg = err instanceof Error ? err.message : "login error";
+          } catch (err: any) {
+            const errMsg = err?.message || "로그인 중 오류가 발생했습니다.";
             set({ isLoading: false, error: errMsg });
             throw err;
           }
         },
 
+        // 로그아웃
         logout: () => {
           try {
             removeToken();
           } catch (err) {
-            console.error("removeToken failed in logout:", err);
+            console.error("로그아웃 중 토큰 제거 실패:", err);
           }
           try {
             new BroadcastChannel("auth").postMessage({ type: "logout" });
           } catch (err) {
-            console.warn(
-              "BroadcastChannel postMessage(logout) failed in logout:",
-              err
-            );
+            console.warn("로그아웃 브로드캐스트 전송 실패:", err);
           }
           set({ user: null, token: null });
         },
 
+        // 최신 정보 갱신
         refreshUser: async () => {
           set({ isLoading: true, error: null });
           try {
@@ -211,30 +175,25 @@ export const useAuthStore = create<State>()(
               set({ isLoading: false, user: null });
               return null;
             }
-            const res = await fetch(`${BASE_URL}/user/myinfo`, {
-              method: "GET",
-              headers: getAuthHeaders(),
-            });
-            const payload = await res.json();
-            if (!res.ok) {
-              removeToken();
-              set({ user: null, token: null, isLoading: false });
-              return null;
-            }
+            const payload = await auth.getMyInfo();
             const user = payload.user as AuthUser;
+
             set({ user, lastFetchedAt: Date.now(), isLoading: false });
             return user;
-          } catch (err: unknown) {
-            const errMsg = err instanceof Error ? err.message : "refresh error";
-            set({
-              user: null,
-              isLoading: false,
-              error: errMsg,
-            });
+          } catch (err: any) {
+            const errMsg = err?.message || "사용자 정보 갱신 실패";
+            // 토큰 무효화 시 제거
+            try {
+              removeToken();
+            } catch (e) {
+              console.warn("갱신 실패 중 토큰 제거 오류:", e);
+            }
+            set({ user: null, token: null, isLoading: false, error: errMsg });
             return null;
           }
         },
 
+        // 일부 변경 업데이트
         updateUser: (partial) => {
           const u = get().user;
           if (!u) return;

--- a/src/pages/home/FeedPage.tsx
+++ b/src/pages/home/FeedPage.tsx
@@ -6,12 +6,14 @@ import { InitialLoadingSection } from "./FeedPage.styled";
 import PostCard from "../../components/post/postCard/PostCard";
 
 import { useFeedStore } from "../../contexts/useFeedStore";
-import { useAuth } from "../../contexts/AuthContext";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 import { reportPost } from "../../services/postService";
 
 const FeedPage = () => {
   const navigate = useNavigate();
-  const { currentUser } = useAuth();
+  // const { currentUser } = useAuth();
+  const currentUser = useAuthStore((s) => s.user);
 
   const toggleLike = useFeedStore((state) => state.toggleLike);
 
@@ -102,51 +104,51 @@ const FeedPage = () => {
 
   return (
     <>
-    <motion.div
-      initial="initial"
-      animate="animate"
-      exit="exit"
-      variants={pageVariants}
-    >
-      {feedList.map((feed, idx) => {
-        const isLast = idx === feedList.length - 1;
-        const isMyPost = currentUser?.accountname === feed.userId;
-        return (
-          <PostCard
-            key={`${feed.id}-${idx}`}
-            postId={feed.id}
-            userName={feed.userName}
-            userId={feed.userId}
-            avatarSrc={feed.profileImg}
-            avatarAlt={`${feed.userName} 프로필`}
-            content={feed.content}
-            imageSrc={feed.image}
-            imageAlt="게시글 이미지"
-            dateTime={feed.createdAt}
-            likeCount={feed.likeCount}
-            commentCount={feed.commentCount}
-            isLiked={feed.isLiked}
-            isMyPost={isMyPost}
-            onLikeClick={() => toggleLike(feed.id)}
-            onCommentClick={() => navigate(`/post/${feed.id}`)}
-            onReportClick={() => handlePostReport(feed.id)}
-            ref={isLast ? lastCardRef : null}
-          />
-        );
-      })}
+      <motion.div
+        initial="initial"
+        animate="animate"
+        exit="exit"
+        variants={pageVariants}
+      >
+        {feedList.map((feed, idx) => {
+          const isLast = idx === feedList.length - 1;
+          const isMyPost = currentUser?.accountname === feed.userId;
+          return (
+            <PostCard
+              key={`${feed.id}-${idx}`}
+              postId={feed.id}
+              userName={feed.userName}
+              userId={feed.userId}
+              avatarSrc={feed.profileImg}
+              avatarAlt={`${feed.userName} 프로필`}
+              content={feed.content}
+              imageSrc={feed.image}
+              imageAlt="게시글 이미지"
+              dateTime={feed.createdAt}
+              likeCount={feed.likeCount}
+              commentCount={feed.commentCount}
+              isLiked={feed.isLiked}
+              isMyPost={isMyPost}
+              onLikeClick={() => toggleLike(feed.id)}
+              onCommentClick={() => navigate(`/post/${feed.id}`)}
+              onReportClick={() => handlePostReport(feed.id)}
+              ref={isLast ? lastCardRef : null}
+            />
+          );
+        })}
 
-      {isRefreshing && hasMore && (
-        <div style={{ textAlign: "center", padding: "20px", color: "#999" }}>
-          로딩중..
-        </div>
-      )}
+        {isRefreshing && hasMore && (
+          <div style={{ textAlign: "center", padding: "20px", color: "#999" }}>
+            로딩중..
+          </div>
+        )}
 
-      {!isRefreshing && (
-        <div style={{ textAlign: "center", padding: "20px", color: "#999" }}>
-          마지막 페이지입니다.
-        </div>
-      )}
-    </motion.div>
+        {!isRefreshing && (
+          <div style={{ textAlign: "center", padding: "20px", color: "#999" }}>
+            마지막 페이지입니다.
+          </div>
+        )}
+      </motion.div>
     </>
   );
 };

--- a/src/pages/home/FeedPage.tsx
+++ b/src/pages/home/FeedPage.tsx
@@ -6,13 +6,11 @@ import { InitialLoadingSection } from "./FeedPage.styled";
 import PostCard from "../../components/post/postCard/PostCard";
 
 import { useFeedStore } from "../../contexts/useFeedStore";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 import { reportPost } from "../../services/postService";
 
 const FeedPage = () => {
   const navigate = useNavigate();
-  // const { currentUser } = useAuth();
   const currentUser = useAuthStore((s) => s.user);
 
   const toggleLike = useFeedStore((state) => state.toggleLike);

--- a/src/pages/login/LoginEmail.tsx
+++ b/src/pages/login/LoginEmail.tsx
@@ -1,9 +1,10 @@
 import React, { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import AuthForm from "../../components/common/auth/AuthForm";
 import styled from "styled-components";
-import { Link, useNavigate } from "react-router-dom";
-import { login } from "../../services/authService";
-import { useAuth } from "../../contexts/AuthContext";
+// import { login } from "../../services/authService";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 
 const LoginTitle = styled.h2`
   text-align: center;
@@ -28,48 +29,10 @@ const SignupLink = styled(Link)`
 
 export default function LoginEmail() {
   const navigate = useNavigate();
-  const { login: authLogin } = useAuth(); // AuthContext의 login 함수
+  // const { login: authLogin } = useAuth();
+  const login = useAuthStore((s) => s.login);
+  const isLoading = useAuthStore((s) => s.isLoading);
   const [formError, setFormError] = useState<string>("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-
-  const handleSubmit = async (
-    e: React.FormEvent<HTMLFormElement>
-  ): Promise<void> => {
-    e.preventDefault();
-    setFormError("");
-
-    const formData = new FormData(e.currentTarget);
-    const email = formData.get("email") as string;
-    const password = formData.get("password") as string;
-
-    setIsSubmitting(true);
-
-    try {
-      const result = await login(email, password);
-
-      if (result.token) {
-        // ✅ AuthContext에 로그인 정보 저장
-        authLogin(result.token, {
-          _id: result._id,
-          username: result.username,
-          accountname: result.accountname,
-          email: result.email,
-          image: result.image,
-          intro: result.intro,
-        });
-
-        navigate("/");
-      }
-    } catch (error) {
-      setFormError(
-        error instanceof Error
-          ? error.message
-          : "알 수 없는 오류가 발생했습니다. 다시 시도해주세요."
-      );
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
 
   // 로그인 폼 필드 설정
   const loginFields = [
@@ -87,14 +50,53 @@ export default function LoginEmail() {
     },
   ];
 
+  const handleSubmit = async (
+    e: React.FormEvent<HTMLFormElement>
+  ): Promise<void> => {
+    e.preventDefault();
+    setFormError("");
+
+    const formData = new FormData(e.currentTarget);
+    const email = formData.get("email") as string;
+    const password = formData.get("password") as string;
+
+    try {
+      // const result = await login(email, password);
+
+      // if (result.token) {
+      //   authLogin(result.token, {
+      //     _id: result._id,
+      //     username: result.username,
+      //     accountname: result.accountname,
+      //     email: result.email,
+      //     image: result.image,
+      //     intro: result.intro,
+      //   });
+
+      //   navigate("/");
+
+      const user = await login(email, password);
+
+      if (user) {
+        navigate("/", { replace: true });
+      }
+    } catch (error) {
+      setFormError(
+        error instanceof Error
+          ? error.message // "이메일 또는 비밀번호가 일치하지 않습니다."
+          : "알 수 없는 오류가 발생했습니다. 다시 시도해주세요."
+      );
+    }
+  };
+
   return (
     <>
       <LoginTitle>로그인</LoginTitle>
       <AuthForm
         fields={loginFields}
-        buttonText={isSubmitting ? "로그인 중..." : "로그인"}
+        buttonText={isLoading ? "로그인 중..." : "로그인"}
         onSubmit={handleSubmit}
-        disabled={isSubmitting}
+        disabled={isLoading}
         formError={formError}
       />
 

--- a/src/pages/login/LoginEmail.tsx
+++ b/src/pages/login/LoginEmail.tsx
@@ -2,8 +2,6 @@ import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import AuthForm from "../../components/common/auth/AuthForm";
 import styled from "styled-components";
-// import { login } from "../../services/authService";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 
 const LoginTitle = styled.h2`
@@ -29,7 +27,6 @@ const SignupLink = styled(Link)`
 
 export default function LoginEmail() {
   const navigate = useNavigate();
-  // const { login: authLogin } = useAuth();
   const login = useAuthStore((s) => s.login);
   const isLoading = useAuthStore((s) => s.isLoading);
   const [formError, setFormError] = useState<string>("");
@@ -61,29 +58,13 @@ export default function LoginEmail() {
     const password = formData.get("password") as string;
 
     try {
-      // const result = await login(email, password);
-
-      // if (result.token) {
-      //   authLogin(result.token, {
-      //     _id: result._id,
-      //     username: result.username,
-      //     accountname: result.accountname,
-      //     email: result.email,
-      //     image: result.image,
-      //     intro: result.intro,
-      //   });
-
-      //   navigate("/");
-
-      const user = await login(email, password);
-
-      if (user) {
-        navigate("/", { replace: true });
-      }
+      await login(email, password);
+      navigate("/", { replace: true });
     } catch (error) {
+      console.error("로그인 에러 확인: ", error);
       setFormError(
         error instanceof Error
-          ? error.message // "이메일 또는 비밀번호가 일치하지 않습니다."
+          ? error.message
           : "알 수 없는 오류가 발생했습니다. 다시 시도해주세요."
       );
     }

--- a/src/pages/post/PostDetail.tsx
+++ b/src/pages/post/PostDetail.tsx
@@ -16,7 +16,8 @@ import {
   reportPost,
   deletePost,
 } from "../../services/postService";
-import { useAuth } from "../../contexts/AuthContext";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 import { useHeader } from "../../contexts/HeaderContext";
 import MoreMenu from "../../components/common/modal/MoreMenu";
 
@@ -72,7 +73,8 @@ function PostDetail() {
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  const { currentUser } = useAuth();
+  // const { currentUser } = useAuth();
+  const currentUser = useAuthStore((s) => s.user);
   const { setHeaderConfig } = useHeader();
   const [commentText, setCommentText] = useState("");
   const [post, setPost] = useState<Post | null>(null);

--- a/src/pages/post/PostDetail.tsx
+++ b/src/pages/post/PostDetail.tsx
@@ -16,7 +16,6 @@ import {
   reportPost,
   deletePost,
 } from "../../services/postService";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 import { useHeader } from "../../contexts/HeaderContext";
 import MoreMenu from "../../components/common/modal/MoreMenu";
@@ -73,7 +72,6 @@ function PostDetail() {
   const { postId } = useParams<{ postId: string }>();
   const navigate = useNavigate();
   const location = useLocation();
-  // const { currentUser } = useAuth();
   const currentUser = useAuthStore((s) => s.user);
   const { setHeaderConfig } = useHeader();
   const [commentText, setCommentText] = useState("");

--- a/src/pages/product/ProductDetail.tsx
+++ b/src/pages/product/ProductDetail.tsx
@@ -3,7 +3,6 @@ import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import { Product } from "../../types/product";
 import { useHeader } from "../../contexts/HeaderContext";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 import {
   deleteProduct,
@@ -264,7 +263,6 @@ export default function ProductDetail() {
   const [product, setProduct] = useState<Product | null>(null);
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
-  // const { currentUser } = useAuth();
   const currentUser = useAuthStore((s) => s.user);
 
   // 헤더 설정

--- a/src/pages/product/ProductDetail.tsx
+++ b/src/pages/product/ProductDetail.tsx
@@ -3,7 +3,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components";
 import { Product } from "../../types/product";
 import { useHeader } from "../../contexts/HeaderContext";
-import { useAuth } from "../../contexts/AuthContext";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 import {
   deleteProduct,
   fetchProductDetail,
@@ -263,7 +264,8 @@ export default function ProductDetail() {
   const [product, setProduct] = useState<Product | null>(null);
   const [isLiked, setIsLiked] = useState(false);
   const [likeCount, setLikeCount] = useState(0);
-  const { currentUser } = useAuth();
+  // const { currentUser } = useAuth();
+  const currentUser = useAuthStore((s) => s.user);
 
   // 헤더 설정
   useEffect(() => {

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useHeader } from "../../contexts/HeaderContext";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 import EditForm from "../../components/common/form/EditForm";
 import {
@@ -33,8 +32,7 @@ export default function ProfileEdit() {
   const [loading, setLoading] = useState(true);
   const [profileData, setProfileData] = useState<UserProfile | null>(null);
   const [error, setError] = useState<string | null>(null);
-  // const { refreshUserInfo } = useAuth();
-  const refreshUserInfo = useAuthStore((s) => s.refreshUser);
+  const refreshUser = useAuthStore((s) => s.refreshUser);
 
   const profileFields = getProfileFields();
 
@@ -141,7 +139,7 @@ export default function ProfileEdit() {
       //console.log("✅ 프로필 수정 성공");
 
       // AuthContext 업데이트 - 서버에서 최신 정보 가져오기
-      await refreshUserInfo();
+      await refreshUser();
       setToast("프로필이 수정되었습니다😎", () =>
         navigate("/profile", { replace: true })
       );

--- a/src/pages/profile/ProfileEdit.tsx
+++ b/src/pages/profile/ProfileEdit.tsx
@@ -1,7 +1,8 @@
 import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { useHeader } from "../../contexts/HeaderContext";
-import { useAuth } from "../../contexts/AuthContext";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 import EditForm from "../../components/common/form/EditForm";
 import {
   CommonFormRef,
@@ -26,13 +27,14 @@ export default function ProfileEdit() {
   const { setHeaderConfig } = useHeader();
   const formRef = useRef<CommonFormRef>(null);
   const [isFormValid, setIsFormValid] = useState(false);
-  const { setToast } = useToastStore()
+  const { setToast } = useToastStore();
 
   // 상태
   const [loading, setLoading] = useState(true);
   const [profileData, setProfileData] = useState<UserProfile | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const { refreshUserInfo } = useAuth();
+  // const { refreshUserInfo } = useAuth();
+  const refreshUserInfo = useAuthStore((s) => s.refreshUser);
 
   const profileFields = getProfileFields();
 
@@ -140,18 +142,22 @@ export default function ProfileEdit() {
 
       // AuthContext 업데이트 - 서버에서 최신 정보 가져오기
       await refreshUserInfo();
-      setToast("프로필이 수정되었습니다😎",()=>navigate("/profile", { replace: true }))
+      setToast("프로필이 수정되었습니다😎", () =>
+        navigate("/profile", { replace: true })
+      );
 
       //navigate("/profile", { replace: true });
     } catch (error) {
       console.error("프로필 수정 실패:", error);
-      setToast("프로필 수정을 실패했습니다😭")
+      setToast("프로필 수정을 실패했습니다😭");
     }
   };
 
   // 🆕 로딩 상태 -> 처리 어떻게 할지
   if (loading) {
-    return <div style={{ textAlign: 'center' }}>프로필 정보를 불러오는 중...</div>;
+    return (
+      <div style={{ textAlign: "center" }}>프로필 정보를 불러오는 중...</div>
+    );
   }
 
   // 🆕 에러 상태 -> 처리 어떻게 할지

--- a/src/pages/profile/ProfileSetup.tsx
+++ b/src/pages/profile/ProfileSetup.tsx
@@ -5,7 +5,6 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import { useState } from "react";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 import { updateProfile } from "../../services/profileService";
 import { uploadImage } from "../../services/imageService";
@@ -42,8 +41,7 @@ export default function ProfileSetup() {
   const [isValid, setIsValid] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { setToast } = useToastStore();
-  // const { refreshUserInfo } = useAuth();
-  const refreshUserInfo = useAuthStore((s) => s.refreshUser);
+  const refreshUser = useAuthStore((s) => s.refreshUser);
 
   // 유효성 검사 상태 변경 핸들러
   const handleValidationChange = (valid: boolean) => {
@@ -85,9 +83,8 @@ export default function ProfileSetup() {
         imageUrl = await uploadImage(imageFile);
       }
       await updateProfile(username, accountname, intro, imageUrl);
+      await refreshUser(); // 프로필 정보 즉시 갱신
       setToast("회원정보가 등록되었습니다😊", () => navigate("/"));
-
-      await refreshUserInfo(); // 프로필 정보 즉시 갱신
     } catch (error) {
       setError(
         error instanceof Error ? error.message : "정보 등록에 실패했습니다."

--- a/src/pages/profile/ProfileSetup.tsx
+++ b/src/pages/profile/ProfileSetup.tsx
@@ -5,7 +5,8 @@ import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 import { useState } from "react";
-import { useAuth } from "../../contexts/AuthContext";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 import { updateProfile } from "../../services/profileService";
 import { uploadImage } from "../../services/imageService";
 import { getToken } from "../../utils/tokenManager";
@@ -41,7 +42,8 @@ export default function ProfileSetup() {
   const [isValid, setIsValid] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { setToast } = useToastStore();
-  const { refreshUserInfo } = useAuth();
+  // const { refreshUserInfo } = useAuth();
+  const refreshUserInfo = useAuthStore((s) => s.refreshUser);
 
   // 유효성 검사 상태 변경 핸들러
   const handleValidationChange = (valid: boolean) => {

--- a/src/pages/profile/components/Profile.tsx
+++ b/src/pages/profile/components/Profile.tsx
@@ -29,15 +29,16 @@ import PostStateBar from "../../../components/post/PostStateBar";
 import PostGallery from "./PostGallery";
 import ProfileImageContainer from "./ProfileImageContainer";
 import { Post } from "../../../types/post";
-import { useAuth } from "../../../contexts/AuthContext";
+// import { useAuth } from "../../../contexts/AuthContext";
 import {
   fetchProfile,
   fetchUserPosts,
   toggleProfileFollow,
 } from "../../../services/profileService";
 import MoreMenu from "../../../components/common/modal/MoreMenu";
+import { useAuthStore } from "../../../contexts/useAuthStore";
 
-const BASE_URL = `https://dev.wenivops.co.kr/services/mandarin`;
+// const BASE_URL = `https://dev.wenivops.co.kr/services/mandarin`;
 
 //  Profile 컴포넌트
 //  - 내 프로필과 다른 유저의 프로필을 조건부 렌더링
@@ -46,7 +47,11 @@ const BASE_URL = `https://dev.wenivops.co.kr/services/mandarin`;
 function Profile() {
   const navigate = useNavigate();
   const { setHeaderConfig } = useHeader();
-  const { currentUser, isLoading: isAuthLoading, logout } = useAuth();
+  // const { currentUser, isLoading: isAuthLoading, logout } = useAuth();
+  const currentUser = useAuthStore((s) => s.user);
+  const isAuthLoading = useAuthStore((s) => s.isLoading);
+  const logout = useAuthStore((s) => s.logout);
+
   // URL 파라미터에서 계정ID 가져오기
   const { accountname: paramAccountname } = useParams<{
     accountname?: string;
@@ -153,6 +158,11 @@ function Profile() {
     );
   };
 
+  const handleLogout = (): void => {
+    logout();
+    navigate("/login", { replace: true });
+  };
+
   useEffect(() => {
     // 헤더 설정
     setHeaderConfig({
@@ -163,7 +173,7 @@ function Profile() {
         <MoreMenu
           type="profile"
           onSettings={() => navigate("/settings")}
-          onLogout={() => logout()}
+          onLogout={handleLogout}
         />
       ),
     });
@@ -261,9 +271,9 @@ function Profile() {
 
             {/* 프로필 이미지 */}
             <ProfileImageContainer
-                src={profileData.image}
-                alt={`${profileData.username}의 프로필 이미지`}
-                onError={handleImageError}
+              src={profileData.image}
+              alt={`${profileData.username}의 프로필 이미지`}
+              onError={handleImageError}
             />
 
             {/* 팔로잉 수 */}

--- a/src/pages/profile/components/Profile.tsx
+++ b/src/pages/profile/components/Profile.tsx
@@ -29,7 +29,6 @@ import PostStateBar from "../../../components/post/PostStateBar";
 import PostGallery from "./PostGallery";
 import ProfileImageContainer from "./ProfileImageContainer";
 import { Post } from "../../../types/post";
-// import { useAuth } from "../../../contexts/AuthContext";
 import {
   fetchProfile,
   fetchUserPosts,
@@ -38,8 +37,6 @@ import {
 import MoreMenu from "../../../components/common/modal/MoreMenu";
 import { useAuthStore } from "../../../contexts/useAuthStore";
 
-// const BASE_URL = `https://dev.wenivops.co.kr/services/mandarin`;
-
 //  Profile 컴포넌트
 //  - 내 프로필과 다른 유저의 프로필을 조건부 렌더링
 //  - isMyProfile = targetAccountname === currentUserAccountname로 구분
@@ -47,12 +44,10 @@ import { useAuthStore } from "../../../contexts/useAuthStore";
 function Profile() {
   const navigate = useNavigate();
   const { setHeaderConfig } = useHeader();
-  // const { currentUser, isLoading: isAuthLoading, logout } = useAuth();
   const currentUser = useAuthStore((s) => s.user);
   const isAuthLoading = useAuthStore((s) => s.isLoading);
   const logout = useAuthStore((s) => s.logout);
 
-  // URL 파라미터에서 계정ID 가져오기
   const { accountname: paramAccountname } = useParams<{
     accountname?: string;
   }>();

--- a/src/pages/profile/components/SellingProducts.tsx
+++ b/src/pages/profile/components/SellingProducts.tsx
@@ -12,7 +12,6 @@ import {
 import ProductImageContainer from "./ProductImageContainer";
 import type { Product } from "../../../types/product";
 import { fetchProductList } from "../../../services/productService";
-// import { useAuth } from "../../../contexts/AuthContext";
 import { useAuthStore } from "../../../contexts/useAuthStore";
 
 interface SellingProductsProps {

--- a/src/pages/profile/components/SellingProducts.tsx
+++ b/src/pages/profile/components/SellingProducts.tsx
@@ -12,7 +12,8 @@ import {
 import ProductImageContainer from "./ProductImageContainer";
 import type { Product } from "../../../types/product";
 import { fetchProductList } from "../../../services/productService";
-import { useAuth } from "../../../contexts/AuthContext";
+// import { useAuth } from "../../../contexts/AuthContext";
+import { useAuthStore } from "../../../contexts/useAuthStore";
 
 interface SellingProductsProps {
   isLastSection?: boolean;
@@ -30,7 +31,8 @@ function SellingProducts({
 }: SellingProductsProps) {
   const navigate = useNavigate();
   const params = useParams<{ accountname?: string }>();
-  const { currentUser } = useAuth();
+  // const { currentUser } = useAuth();
+  const currentUser = useAuthStore((s) => s.user);
 
   const [products, setProducts] = useState<Product[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -203,9 +205,9 @@ function SellingProducts({
               role="listitem"
             >
               <ProductImageContainer
-              src={getProductImageUrl(product.itemImage)}
-              alt={product.itemName}
-              onError={(e)=>handleImageError(e)}
+                src={getProductImageUrl(product.itemImage)}
+                alt={product.itemName}
+                onError={(e) => handleImageError(e)}
               />
 
               <ProductInfoBox>

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -2,9 +2,6 @@ import React, { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
 import AuthForm from "../../components/common/auth/AuthForm";
-// import { signup, login } from "../../services/authService";
-// import { saveToken } from "../../utils/tokenManager";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 import {
   validateEmail,
@@ -38,7 +35,6 @@ const LoginLink = styled(Link)`
 export default function Signup() {
   const navigate = useNavigate();
   const [formError, setFormError] = useState<string>("");
-  // const { refreshUserInfo } = useAuth();
   const { setToast } = useToastStore();
   const signup = useAuthStore((s) => s.signup);
   const isLoading = useAuthStore((state) => state.isLoading);
@@ -79,16 +75,8 @@ export default function Signup() {
     const password = formData.get("password") as string;
 
     try {
-      // await signup(email, password);
-      // const loginResult = await login(email, password);
-      // saveToken(loginResult.token);
-      // await refreshUserInfo();
-
-      const user = await signup(email, password);
-
-      if (user) {
-        setToast("회원가입 완료😊", () => navigate("/profile/setup"));
-      }
+      await signup(email, password);
+      setToast("회원가입 완료😊", () => navigate("/profile/setup"));
     } catch (error) {
       setFormError(
         error instanceof Error

--- a/src/pages/signup/Signup.tsx
+++ b/src/pages/signup/Signup.tsx
@@ -1,16 +1,17 @@
 import React, { useState } from "react";
-import AuthForm from "../../components/common/auth/AuthForm";
-import styled from "styled-components";
 import { Link, useNavigate } from "react-router-dom";
-import { signup, login } from "../../services/authService";
-import { saveToken } from "../../utils/tokenManager";
-import { useAuth } from "../../contexts/AuthContext";
+import styled from "styled-components";
+import AuthForm from "../../components/common/auth/AuthForm";
+// import { signup, login } from "../../services/authService";
+// import { saveToken } from "../../utils/tokenManager";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 import {
   validateEmail,
   validatePassword,
   validateEmailDuplicate,
 } from "../../utils/validation/AuthValidation";
-import { toast } from "react-toastify";
+// import { toast } from "react-toastify";
 import { useToastStore } from "../../contexts/useToastStore";
 
 const Signuptitle = styled.h2`
@@ -34,14 +35,13 @@ const LoginLink = styled(Link)`
   }
 `;
 
-
-
 export default function Signup() {
   const navigate = useNavigate();
   const [formError, setFormError] = useState<string>("");
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { refreshUserInfo } = useAuth();
+  // const { refreshUserInfo } = useAuth();
   const { setToast } = useToastStore();
+  const signup = useAuthStore((s) => s.signup);
+  const isLoading = useAuthStore((state) => state.isLoading);
 
   // 회원가입 폼 필드 설정
   const signupFields = [
@@ -72,7 +72,6 @@ export default function Signup() {
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    setIsSubmitting(true);
     setFormError("");
 
     const formData = new FormData(e.currentTarget);
@@ -80,23 +79,22 @@ export default function Signup() {
     const password = formData.get("password") as string;
 
     try {
-      await signup(email, password);
+      // await signup(email, password);
+      // const loginResult = await login(email, password);
+      // saveToken(loginResult.token);
+      // await refreshUserInfo();
 
-      const loginResult = await login(email, password);
+      const user = await signup(email, password);
 
-      saveToken(loginResult.token);
-
-      await refreshUserInfo(); // 사용자 정보 즉시 갱신
-      setToast("회원가입 완료😊")
-
+      if (user) {
+        setToast("회원가입 완료😊", () => navigate("/profile/setup"));
+      }
     } catch (error) {
       setFormError(
         error instanceof Error
           ? error.message
           : "알 수 없는 오류가 발생했습니다. 다시 시도해주세요."
       );
-    } finally {
-      setIsSubmitting(false);
     }
   };
 
@@ -105,7 +103,7 @@ export default function Signup() {
       <Signuptitle>회원가입</Signuptitle>
       <AuthForm
         fields={signupFields}
-        buttonText={isSubmitting ? "처리 중..." : "회원가입"}
+        buttonText={isLoading ? "처리 중..." : "회원가입"}
         onSubmit={handleSubmit}
         formError={formError}
       />

--- a/src/pages/splash/Splash.tsx
+++ b/src/pages/splash/Splash.tsx
@@ -2,12 +2,10 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Variants } from "framer-motion";
 import { SplashContainer, LogoWrapper, LogoImage } from "./Splash.styled";
-// import { useAuth } from "../../contexts/AuthContext";
 import { useAuthStore } from "../../contexts/useAuthStore";
 
 function Splash() {
   const navigate = useNavigate();
-  // const { isAuthenticated } = useAuth();
   const user = useAuthStore((s) => s.user);
   const isAuthenticated = !!user;
 

--- a/src/pages/splash/Splash.tsx
+++ b/src/pages/splash/Splash.tsx
@@ -2,11 +2,15 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 import { Variants } from "framer-motion";
 import { SplashContainer, LogoWrapper, LogoImage } from "./Splash.styled";
-import { useAuth } from "../../contexts/AuthContext";
+// import { useAuth } from "../../contexts/AuthContext";
+import { useAuthStore } from "../../contexts/useAuthStore";
 
 function Splash() {
   const navigate = useNavigate();
-  const { isAuthenticated } = useAuth();
+  // const { isAuthenticated } = useAuth();
+  const user = useAuthStore((s) => s.user);
+  const isAuthenticated = !!user;
+
   useEffect(() => {
     const checkAuthAndRedirect = async () => {
       const timer = setTimeout(() => {

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,6 +1,5 @@
 // API 호출 관리 서비스
 const BASE_URL = "https://dev.wenivops.co.kr/services/mandarin";
-const DEFAULT_PROFILE_IMG = "/img/empty-profile.png";
 
 export interface AuthResponse {
   message: string;
@@ -25,11 +24,16 @@ export interface LoginResponse {
   token: string;
 }
 
+export interface LoginErrorReponse {
+  message: string;
+  status: number;
+}
+
 export interface CheckDuplicateResponse {
   message: string;
 }
 
-// 이메일 중복 체크
+// 이메일 중복 체크 API
 export const checkEmailDuplicate = async (
   email: string
 ): Promise<CheckDuplicateResponse> => {
@@ -50,7 +54,7 @@ export const checkEmailDuplicate = async (
   return data;
 };
 
-// 계정 ID 중복 체크
+// 계정 ID 중복 API
 export const checkAccountIdDuplicate = async (
   accountId: string
 ): Promise<CheckDuplicateResponse> => {
@@ -71,30 +75,22 @@ export const checkAccountIdDuplicate = async (
   return data;
 };
 
-// 회원가입
-export const signup = async (
-  email: string,
-  password: string
-): Promise<AuthResponse> => {
-  // 임시 username과 accountname 생성 (나중에 프로필 설정에서 변경)
-  const timestamp = Date.now();
-  const tempUsername = `user_${timestamp}`;
-  const tempAccountname = `account_${timestamp}`;
-
+// 회원가입 API
+export const signup = async (payload: {
+  username: string;
+  email: string;
+  password: string;
+  accountname: string;
+  intro?: string;
+  image?: string;
+}): Promise<AuthResponse> => {
   const response = await fetch(`${BASE_URL}/user`, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      user: {
-        username: tempUsername,
-        email: email,
-        password: password,
-        accountname: tempAccountname,
-        intro: "",
-        image: DEFAULT_PROFILE_IMG,
-      },
+      user: payload,
     }),
   });
 
@@ -107,7 +103,7 @@ export const signup = async (
   return data;
 };
 
-// 로그인
+// 로그인 API
 export const login = async (
   email: string,
   password: string

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,3 +1,5 @@
+import { getAuthHeaders } from "../utils/tokenManager";
+
 // API 호출 관리 서비스
 const BASE_URL = "https://dev.wenivops.co.kr/services/mandarin";
 
@@ -124,8 +126,24 @@ export const login = async (
   const data = await response.json();
 
   if (!response.ok) {
+    console.log("API 응답 실패:", response.status, data); // 확인
     throw new Error("이메일 또는 비밀번호가 일치하지 않습니다.");
   }
 
   return data;
+};
+
+export const getMyInfo = async () => {
+  const response = await fetch(`${BASE_URL}/user/myinfo`, {
+    method: "GET",
+    headers: getAuthHeaders(),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    throw new Error("사용자 정보를 불러오는 데 실패했습니다.");
+  }
+
+  return data; // { user: {} }
 };

--- a/src/services/imageService.ts
+++ b/src/services/imageService.ts
@@ -16,18 +16,17 @@ export const uploadImage = async (file: File): Promise<string> => {
 
   const data = await response.json();
 
-  // ✅ filename이 없으면 에러
+  // filename이 없으면 에러
   if (!data.info.filename) {
-    console.error("❌ filename이 없습니다:", data);
     throw new Error("이미지 업로드 후 파일명을 받지 못했습니다.");
   }
 
-  // ✅ 이미 전체 URL이면 그대로 반환
+  // 이미 전체 URL이면 그대로 반환
   if (data.info.filename.startsWith("http")) {
     return data.info.filename;
   }
 
-  // ✅ 상대 경로면 전체 URL 생성
+  // 상대 경로면 전체 URL 생성
   const fullUrl = `${API_BASE_URL}/${data.info.filename}`;
 
   return fullUrl;

--- a/src/services/productService.ts
+++ b/src/services/productService.ts
@@ -128,7 +128,7 @@ export const deleteProduct = async (productId: string): Promise<void> => {
     throw new Error(`상품 삭제 실패: ${response.status}`);
   }
 
-  const data = await response.json();
+  // const data = await response.json();
 
   // 삭제만 하면 되니까 반환 하지 않음
 };
@@ -157,8 +157,6 @@ export const fetchProductList = async (
   }
 
   const data = await response.json();
-
-  console.log("📦 상품 리스트: ", data); // { data, product: [] }
 
   return data;
 };

--- a/src/utils/GuestRoute.tsx
+++ b/src/utils/GuestRoute.tsx
@@ -1,17 +1,24 @@
 import { ReactNode, useEffect } from "react";
 import ExceptionPage from "../pages/errPage/ExceptionPage";
 import { getToken } from "./tokenManager";
-import { useAuth } from "../contexts/AuthContext";
+// import { useAuth } from "../contexts/AuthContext";
+import { useAuthStore } from "../contexts/useAuthStore";
 interface Props {
   children: ReactNode;
 }
 
 //login
-export default function GuestRoute({children}:Props) {
-  const { isLoading } = useAuth();
-    if(isLoading) return null;
+export default function GuestRoute({ children }: Props) {
+  // const { isLoading } = useAuth();
+  const isLoading = useAuthStore((s) => s.isLoading);
+  if (isLoading) return null;
 
-    const token = getToken();
-    if(!token) return <><ExceptionPage text="로그인이 필요한 서비스입니다! :)" type="guest" /></>
-    return <>{children}</>
+  const token = getToken();
+  if (!token)
+    return (
+      <>
+        <ExceptionPage text="로그인이 필요한 서비스입니다! :)" type="guest" />
+      </>
+    );
+  return <>{children}</>;
 }

--- a/src/utils/GuestRoute.tsx
+++ b/src/utils/GuestRoute.tsx
@@ -1,7 +1,6 @@
 import { ReactNode, useEffect } from "react";
 import ExceptionPage from "../pages/errPage/ExceptionPage";
 import { getToken } from "./tokenManager";
-// import { useAuth } from "../contexts/AuthContext";
 import { useAuthStore } from "../contexts/useAuthStore";
 interface Props {
   children: ReactNode;
@@ -9,7 +8,6 @@ interface Props {
 
 //login
 export default function GuestRoute({ children }: Props) {
-  // const { isLoading } = useAuth();
   const isLoading = useAuthStore((s) => s.isLoading);
   if (isLoading) return null;
 

--- a/src/utils/MemberRoute.tsx
+++ b/src/utils/MemberRoute.tsx
@@ -1,19 +1,25 @@
 import { ReactNode } from "react";
 import ExceptionPage from "../pages/errPage/ExceptionPage";
 import { getToken } from "./tokenManager";
-import { useAuth } from "../contexts/AuthContext";
+// import { useAuth } from "../contexts/AuthContext";
+import { useAuthStore } from "../contexts/useAuthStore";
 interface Props {
   children: ReactNode;
 }
 
 //login 되어있을때
 
-export default function MemberRoute({children}:Props) {
-  const { isLoading } = useAuth();
+export default function MemberRoute({ children }: Props) {
+  // const { isLoading } = useAuth();
+  const isLoading = useAuthStore((s) => s.isLoading);
 
-  if(isLoading) return null;
+  if (isLoading) return null;
   const token = getToken();
   if (token)
-    return <><ExceptionPage text="이미 로그인 되어있어요 :)" type="member" /></>
-  return <>{children}</>
+    return (
+      <>
+        <ExceptionPage text="이미 로그인 되어있어요 :)" type="member" />
+      </>
+    );
+  return <>{children}</>;
 }

--- a/src/utils/MemberRoute.tsx
+++ b/src/utils/MemberRoute.tsx
@@ -1,8 +1,7 @@
 import { ReactNode } from "react";
 import ExceptionPage from "../pages/errPage/ExceptionPage";
 import { getToken } from "./tokenManager";
-// import { useAuth } from "../contexts/AuthContext";
-import { useAuthStore } from "../contexts/useAuthStore";
+
 interface Props {
   children: ReactNode;
 }
@@ -10,10 +9,6 @@ interface Props {
 //login 되어있을때
 
 export default function MemberRoute({ children }: Props) {
-  // const { isLoading } = useAuth();
-  const isLoading = useAuthStore((s) => s.isLoading);
-
-  if (isLoading) return null;
   const token = getToken();
   if (token)
     return (


### PR DESCRIPTION
대대적인 수정...줄여서 대수정...

### AuthContext → useAuthStore(zustand store)로 전환

흐름대로 액션을 묶어서

- 회원가입(signup) → 자동 로그인 → 프로필 설정 → 사용자 정보 업데이트
- 로그인(login) → 토큰 저장 → 사용자 정보 업데이트 해서 가져오기
- 로그아웃(logout) → 토큰 제거, 유저 정보 초기화(null) → `BroadcastChannel` 를 통해 다른 탭들에도 즉시 로그아웃 알리기 (새로고침)

이렇게 동작하도록 만들어서 호출부에서 **await**와 같이 써주면 user가 세팅 된 뒤 다음 동작을 실행할 수 있게 해서 타이밍 이슈를 줄일 수 있게 했습니다.

그리고 zustand persist 미들웨어를 써서 
localStorate에 민감한 정보(token)를 제외한 user 정보(_id, username, accountname)를 저장하게 해서, 
새로고침 후에도 user 정보를 빠르게 복원할 수 있게 했습니다.

<br />

적용 예시
```ts
// 기존
import { signup, login } from "../../services/authService";
import { saveToken } from "../../utils/tokenManager";
import { useAuth } from "../../contexts/AuthContext";

const { refreshUserInfo } = useAuth();

await signup(email, password);
const loginResult = await login(email, password);
saveToken(loginResult.token);
await refreshUserInfo();
setToast("회원가입 완료😊", () => navigate("/profile/setup"));


// new 
import { useAuthStore } from "../../contexts/useAuthStore";

const signup = useAuthStore((s) => s.signup);
const isLoading = useAuthStore((state) => state.isLoading);

const user = await signup(email, password);

if (user) {
   setToast("회원가입 완료😊", () => navigate("/profile/setup"));
}
```

주요 변경 사항
```md
currentUser → user
isAuthenticated → !!user
isLoading → isLoading
login(token, user) → login(email, password)
logout() → logout()
updateUser(partial) → updateUser(partial)
refreshUserInfo() → refreshUser()
```
